### PR TITLE
Fix #4

### DIFF
--- a/cl-cpus-bsd.lisp
+++ b/cl-cpus-bsd.lisp
@@ -3,9 +3,9 @@
 (defconstant +ctl-hw+ 6)
 (defconstant +hw-ncpu+ 3)
 
-;; sysctl(int *name, u_int namelen, void *oldp, size_t *oldlenp, void *newp,
-;;        size_t newlen);
-(cffi:defcfun "sysctl" :long
+;; int sysctl(int *name, u_int namelen, void *oldp, size_t *oldlenp, void *newp,
+;;            size_t newlen);
+(cffi:defcfun "sysctl" :int
   (name    :pointer)
   (namelen :unsigned-int)
   (oldp    :pointer)
@@ -17,12 +17,13 @@
   (cffi:with-foreign-object (name-pointer :int 2)
     (setf (cffi:mem-aref name-pointer :int 0) +ctl-hw+)
     (setf (cffi:mem-aref name-pointer :int 1) +hw-ncpu+)
-    (cffi:with-foreign-objects ((oldp :pointer)
-                                (oldlenp :pointer))
+    (cffi:with-foreign-objects ((oldp :uint)
+                                (oldlenp :size))
+      (setf (cffi:mem-ref oldlenp :size) (cffi:foreign-type-size :uint))
       (let ((result (sysctl name-pointer 2 oldp oldlenp (cffi:null-pointer) 0)))
         (if (/= 0 result)
             0
-            (cffi:mem-ref oldp :int))))))
+            (cffi:mem-ref oldp :uint))))))
 
 (defun get-number-of-processors ()
   "Get CPU Threads count."


### PR DESCRIPTION
`oldlenp` was not correctly initialized according to `man 3 sysctl`.

> The information is copied into the buffer specified by oldp.  The size of
     the buffer is given by the location specified by oldlenp before the call,
     and that location gives the amount of data copied after a successful call
     and after a call that returns with the error code ENOMEM.

This should fix the problem on macOS/OS X, and potentially other BSDs.